### PR TITLE
Dynamic Ip Assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,33 @@ To destroy the created VMs:
 terraform destroy -auto-approve
 ```
 
-### Guide
+### Guide to create an Ubuntu-Server template with cloud-init for terrerform deployment
+
+```sh
+wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+```
+##### Convert the image to a proxmox-compatible format
+```sh
+qm create 9000 --name "ubuntu-template" --memory 2048 --cores 2 --net0 virtio,bridge=vmbr0
+qm importdisk 9000 jammy-server-cloudimg-amd64.img local-lvm
+qm set 9000 --scsihw virtio-scsi-pci --scsi0 local-lvm:vm-9000-disk-0
+qm set 9000 --ide2 local-lvm:cloudinit
+qm set 9000 --boot c --bootdisk scsi0
+qm set 9000 --serial0 socket --vga serial0
+```
+##### Configure cloud-init
+
+```sh
+qm set 9000 --ipconfig0 ip=dhcp
+qm set 9000 --sshkeys ~/.ssh/id_rsa.pub  # Your SSH key for access
+```
+#### convert VM to template
+
+```sh
+qm template 9000
+```
+
+#### Other Notes That are still relevant
 
 Pull Ubuntu 22.04 ISO
 
@@ -82,11 +108,6 @@ Create keypair
 `ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N ""`
 
 Reference the key terraform.tfvars you can find you key by running `cat ~/.ssh/id_rsa.pub`
-
-
-
-
-
 
 
 #### Author: Jared Wilson

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "proxmox_vm_qemu" "ubuntu" {
   count       = var.vm_count
   name        = "${var.vm_name}-${count.index + 1}"
   target_node = "proxmox"         # Change to your Proxmox node name
-  clone       = "ubuntu-template" # Change to your template name
+  clone       = "reclone" # Change to your template name
 
   cores  = var.vm_cores
   memory = var.vm_memory
@@ -22,9 +22,16 @@ resource "proxmox_vm_qemu" "ubuntu" {
   }
 
   os_type = "cloud-init"
-  sshkeys = var.ssh_key # Pass SSH key directly as a string
+  ipconfig0 = "ip=${var.vm_ip_base}${count.index + var.vm_ip_start}/24,gw=${var.vm_gateway}"
+  sshkeys = var.ssh_key
+
+  ciuser = "homelabdad"  # or your template's default user
+  nameserver = "8.8.8.8" # google dns
+  searchdomain = "vermillion.local" # local domain
+
+  automatic_reboot = true
 
   lifecycle {
-    ignore_changes = [network, sshkeys]
+    ignore_changes = [sshkeys]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "proxmox_vm_qemu" "ubuntu" {
   count       = var.vm_count
   name        = "${var.vm_name}-${count.index + 1}"
   target_node = "proxmox"         # Change to your Proxmox node name
-  clone       = "reclone" # Change to your template name
+  clone       = "ubuntu-template" # Change to your template name
 
   cores  = var.vm_cores
   memory = var.vm_memory
@@ -12,6 +12,12 @@ resource "proxmox_vm_qemu" "ubuntu" {
     slot    = "scsi0"
     size    = var.vm_disk_size
     type    = "disk"
+    storage = "local-lvm"
+  }
+  disk {
+    slot    = "ide2"
+    size    = "4M"
+    type    = "cloudinit"
     storage = "local-lvm"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,6 @@ resource "proxmox_vm_qemu" "ubuntu" {
   automatic_reboot = true
 
   lifecycle {
-    ignore_changes = [sshkeys]
+    ignore_changes = [network, sshkeys]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -27,12 +27,12 @@ resource "proxmox_vm_qemu" "ubuntu" {
     bridge = var.vm_network
   }
 
-  os_type = "cloud-init"
+  os_type   = "cloud-init"
   ipconfig0 = "ip=${var.vm_ip_base}${count.index + var.vm_ip_start}/24,gw=${var.vm_gateway}"
-  sshkeys = var.ssh_key
+  sshkeys   = var.ssh_key
 
-  ciuser = "homelabdad"  # or your template's default user
-  nameserver = "8.8.8.8" # google dns
+  ciuser       = "homelabdad"       # or your template's default user
+  nameserver   = "8.8.8.8"          # google dns
   searchdomain = "vermillion.local" # local domain
 
   automatic_reboot = true

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,19 @@ variable "ssh_key" {
   description = "SSH public key string for VM access"
   type        = string
 }
+
+variable "vm_ip_base" {
+  description = "Base IP address (first 3 octets, e.g., '192.168.1.')"
+  type        = string
+}
+
+variable "vm_ip_start" {
+  description = "Starting number for the last octet of IP addresses"
+  type        = number
+  default     = 1
+}
+
+variable "vm_gateway" {
+  description = "Gateway IP address for the network"
+  type        = string
+}


### PR DESCRIPTION
Adds variables that can be used to assign Ip addresses dynamically to the VMs that are stood up. 

I also moved to a new template and included instructions to create this template in the `README.md`

I want to get this merged in and then modify the deployment so that there are separate configs

- Worker Node
- Control Node

Closes #2 